### PR TITLE
Bug: fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM golang AS build
-RUN go get -u -v github.com/wrouesnel/p2cli
+FROM golang:1.14 AS build
+RUN go get -v github.com/wrouesnel/p2cli
 WORKDIR $GOPATH/src/github.com/wrouesnel/p2cli
 RUN CGO_ENABLED=0 GOOS=linux go build -a \
     -ldflags "-extldflags '-static' -X main.Version=$(shell git describe --long --dirty)" \

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ users:
 
 Now executing the template:
 ```sh
-$ p2 -t template.p2 -i input.yml --enable-filters write_file
+$ p2 -t template.p2 -i input.yml -f yaml --enable-filters write_file
 
 
 


### PR DESCRIPTION
- Mitigates docker build issue (#18) by locking the golang and package versions 
- Typo: Missing `--format` arg. in example causes error
`p2 -t ./template.p2 -i ./input.yml --enable-filters write_file`
```
ERRO[0000] Error parsing input data: Could not find an equals value to split on: users:  data=./input.yml source=p2cli.go:323 template=./template.p2
```