### PR TITLE
Add --include-env functionality

### DIFF
--- a/cmd/p2/inputprocessors.go
+++ b/cmd/p2/inputprocessors.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"strings"
+)
+
+// fromEnvironment consumes the environment and outputs a valid input data field into the
+// supplied map.
+func fromEnvironment(inputData map[string]interface{}) error {
+	if inputData == nil {
+		return errors.New("nil inputData map supplied")
+	}
+
+	for _, keyval := range os.Environ() {
+		splitKeyVal := strings.SplitN(keyval, "=", 2)
+		if len(splitKeyVal) != 2 {
+			return error(ErrorEnvironmentVariables{
+				Reason:    "Could not find an equals value to split on",
+				RawEnvVar: keyval,
+			})
+		}
+
+		// os.Environ consumption has special-case logic. Since there's all sorts of things
+		// which can end up in the environment, we want to filter here only for keys which we
+		// like.
+		if reIdentifiers.MatchString(splitKeyVal[0]) {
+			inputData[splitKeyVal[0]] = splitKeyVal[1]
+		}
+	}
+
+	return nil
+}

--- a/cmd/p2/tests/data.out.overridden
+++ b/cmd/p2/tests/data.out.overridden
@@ -1,0 +1,2 @@
+a value
+a value

--- a/data.invalid.env
+++ b/data.invalid.env
@@ -1,0 +1,2 @@
+a value
+a value

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wrouesnel/p2cli
 
-go 1.17
+go 1.18
 
 require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible


### PR DESCRIPTION
--include-env forces the inclusion of environment variables regardless
of the use of data file input. Environment variables take precedence over
values from data files.

Closes #28 